### PR TITLE
Add pinch to zoom for Android

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -95,6 +95,12 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     webView.getSettings().setDomStorageEnabled(true);
     webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);
 
+    // Allow zoom
+    webView.getSettings().setBuiltInZoomControls(true);
+
+    // Hide buttons.
+    webView.getSettings().setDisplayZoomControls(false);
+
     // Multi windows is set with FlutterWebChromeClient by default to handle internal bug: b/159892679.
     webView.getSettings().setSupportMultipleWindows(true);
     webView.setWebChromeClient(new FlutterWebChromeClient());


### PR DESCRIPTION
Android のズームイン、ズームアウトを追加


元々は [かもさんのリポジトリ](https://github.com/kamomc/plugins/tree/master/packages/webview_flutter) で管理してたが、Flutter 1.22.4 でビルドできなかったので、こちらに移動。

ブランチは [このコミット](https://github.com/flutter/plugins/commit/d256f56779b292f978f6b4e543fe039cc187a479#diff-4d3689096982b2df3f1b82ec24940f9ddb5c5ccf7697386a4891619013eb6a7f) から切っている。

理由は [senken](https://github.com/retromeme/app.senken.co.jp) の fvm が Flutter 1.22.4 stable になっていて、 pub get を行った時に、インストールされた webview_flutter が 1.0.7 だったため。